### PR TITLE
NL layer phase 1: normalize query, hint UX, --debug EN only

### DIFF
--- a/core/logutil.py
+++ b/core/logutil.py
@@ -1,4 +1,4 @@
-"""Debug logging: --debug / --дебаг or env JUST_DEBUG=1."""
+"""Debug logging: --debug or env JUST_DEBUG=1."""
 
 from __future__ import annotations
 

--- a/core/nl.py
+++ b/core/nl.py
@@ -1,0 +1,41 @@
+"""
+Natural-language preprocessing for the launcher.
+
+Strips conversational filler so existing runners (converter, timer, files, …)
+match the same query with or without phrases like «сколько будет», «please».
+Explicit modes (.prefix, !bang, =, >, ?, !!, $) are left unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+
+_LEADING_FILLER = re.compile(
+    r"^\s*(?:"
+    r"пожалуйста|please|скажи|tell\s+me|сколько\s+будет|how\s+much\s+is|"
+    r"переведи|translate|convert|позволь|можно|"
+    r"найди|find|открой|open|запусти|launch|run|"
+    r"напомни(?:\s+меня)?|remind\s+me"
+    r")\s+",
+    re.IGNORECASE,
+)
+
+
+def should_skip_nl_normalize(query: str) -> bool:
+    q = query.lstrip()
+    if not q:
+        return True
+    if q.startswith("!!"):
+        return True
+    if q[0] in ".!?>=$":
+        return True
+    return False
+
+
+def normalize_for_runners(query: str) -> str:
+    """Return text passed to runners; safe no-op for magic-prefixed lines."""
+    q = query.strip()
+    if not q or should_skip_nl_normalize(q):
+        return q
+    stripped = _LEADING_FILLER.sub("", q, count=1).strip()
+    return stripped if stripped else q

--- a/runner.py
+++ b/runner.py
@@ -7,7 +7,7 @@ Usage:
   python3 runner.py --check          — validate all modules load, exit 0/1
   python3 runner.py --query "текст"  — run query headless, print results as JSON
   python3 runner.py --interactive    — REPL: type queries, see results in terminal
-  python3 runner.py --debug           — подробные логи (или --дебаг)
+  python3 runner.py --debug           — verbose logs
 """
 
 import sys
@@ -96,15 +96,17 @@ def _cli_check():
 def _cli_query(query: str):
     """Run a query headless, print JSON results."""
     os.environ["QT_QPA_PLATFORM"] = "offscreen"
+    from core.nl import normalize_for_runners
     from runners import discover_runners
     runners = discover_runners()
+    nq = normalize_for_runners(query)
 
     results = []
     for runner in runners:
         if getattr(runner, "is_ai", False):
             continue
         try:
-            results.extend(runner.match(query))
+            results.extend(runner.match(nq))
         except Exception as e:
             print(f"[WARN] {type(runner).__name__}: {e}", file=sys.stderr)
 
@@ -133,6 +135,7 @@ def _cli_query(query: str):
 def _cli_interactive():
     """REPL mode: type queries, see results in terminal."""
     os.environ["QT_QPA_PLATFORM"] = "offscreen"
+    from core.nl import normalize_for_runners
     from runners import discover_runners
     runners = discover_runners()
     names = [type(r).__name__ for r in runners]
@@ -148,12 +151,13 @@ def _cli_interactive():
         if not query:
             continue
 
+        nq = normalize_for_runners(query)
         results = []
         for runner in runners:
             if getattr(runner, "is_ai", False):
                 continue
             try:
-                results.extend(runner.match(query))
+                results.extend(runner.match(nq))
             except Exception as e:
                 print(f"  [ERR] {type(runner).__name__}: {e}")
 
@@ -380,7 +384,6 @@ def main():
     parser.add_argument("--interactive", "-i", action="store_true", help="Interactive REPL mode")
     parser.add_argument(
         "--debug",
-        "--дебаг",
         action="store_true",
         help="Verbose logging to stderr and ~/.local/share/just/just-debug.log",
     )

--- a/ui/prefix_hints.py
+++ b/ui/prefix_hints.py
@@ -1,12 +1,11 @@
-"""One-line hint under the search field for the active prefix / mode."""
+"""One-line hint under the search field (only when relevant: text, “.”, or “!”)."""
 
 from __future__ import annotations
 
 from typing import Optional
 
-# Shown when input is empty (idle / defaults).
-IDLE_HINT = (
-    "Префиксы: .app · .file · .web · .погода · .timer · .media · .конвертер · = · !g · > · ? · !!"
+_PREFIX_CHEATSHEET = (
+    "Префикс: .app · .file · .web · .погода · .timer · .media · .конвертер"
 )
 
 _CAT_LABELS: dict[str, str] = {
@@ -32,6 +31,8 @@ _CAT_LABELS: dict[str, str] = {
     "музыка": "медиа-клавиши (playerctl)",
 }
 
+_BANG_SHORT = "!бэнг: !g поиск · !w вики · !yt YouTube — пробел и запрос"
+
 
 def prefix_hint(raw: str, cat_filt: Optional[str]) -> str:
     s = (raw or "").strip()
@@ -42,10 +43,28 @@ def prefix_hint(raw: str, cat_filt: Optional[str]) -> str:
         return f".{cat_filt} — режим: {what}"
 
     if not s:
-        return IDLE_HINT
+        return ""
 
     if low == "!!" or low.startswith("!! "):
         return "!! — повторить последнюю успешную команду (не сохраняются строки с > или $)"
+
+    if s.startswith(".") and " " not in s:
+        tail = s[1:].lower()
+        if not tail:
+            return _PREFIX_CHEATSHEET
+        if tail in _CAT_LABELS:
+            return f"{s} — {_CAT_LABELS[tail]} · пробел и запрос"
+        return f"{s} — неизвестный префикс · примеры: .app .file .web"
+
+    if s.startswith("!") and not s.startswith("!!"):
+        if s.startswith("!g ") or s.startswith("!g\t"):
+            return "!g — открыть поиск Google в браузере"
+        if s.startswith("!w ") or s.startswith("!yt "):
+            return "!w — Википедия · !yt — YouTube · !g — Google (см. !gh !tr !ya …)"
+        if " " not in s:
+            if s == "!":
+                return _BANG_SHORT
+            return f"{s} — пробел и запрос (!g …, !w …, !yt …)"
 
     if s.startswith(">"):
         return "> — команда shell: Enter — внешний терминал · Ctrl+Space — превью PTY (bash)"
@@ -55,12 +74,6 @@ def prefix_hint(raw: str, cat_filt: Optional[str]) -> str:
 
     if s.startswith("="):
         return "= — калькулятор (дроби, sin, sqrt…); Tab — часто выполняет первый результат"
-
-    if s.startswith("!g ") or s.startswith("!g\t"):
-        return "!g — открыть поиск Google в браузере"
-
-    if s.startswith("!w ") or s.startswith("!yt "):
-        return "!w — Википедия · !yt — YouTube · !g — Google (см. !gh !tr !ya …)"
 
     if s.startswith("?"):
         return "? — запрос к AI (нужен ключ в конфиге)"
@@ -80,7 +93,6 @@ def prefix_hint(raw: str, cat_filt: Optional[str]) -> str:
     if low.startswith("таймер") or low.startswith("timer"):
         return "Таймер: «5 мин», «1ч 20м», «90 сек» или будильник «14:30 чай»"
 
-    # Loose hints for natural converter phrasing
     if any(
         x in low
         for x in (
@@ -108,4 +120,4 @@ def prefix_hint(raw: str, cat_filt: Optional[str]) -> str:
             return "Валюта: «100 usd в rub» · «50 € в руб»"
         return "Единицы: «5 миль в км» · «180 см в футы» · «25 c в f» · «2 л в мл»"
 
-    return IDLE_HINT
+    return ""

--- a/ui/window.py
+++ b/ui/window.py
@@ -18,6 +18,7 @@ from PyQt6.QtGui import (
 )
 
 from core.config import MAX_RESULTS, WINDOW_WIDTH, CORNER_RADIUS, ITEM_HEIGHT, home
+from core.nl import normalize_for_runners
 from core.last_repeat import load_last_repeat, save_last_repeat_if_eligible
 from runners.weather import WeatherRunner
 from runners.resource_snapshot import idle_resource_result
@@ -47,7 +48,6 @@ INPUT_DEBOUNCE_MS = 220
 # Must match results_layout margins (4+4) and setSpacing(2).
 _RESULTS_LIST_MARGIN_V = 8
 _RESULTS_LIST_SPACING = 2
-_WINDOW_INPUT_BLOCK_H = 76  # input 48 + prefix hint ~27 + separator 1
 _WINDOW_LIST_TAIL_PAD = 16
 
 _INSTANT_RUNNERS = {"CalcRunner", "ShellRunner", "WebRunner", "MediaRunner"}
@@ -312,8 +312,23 @@ class JustWindow(QWidget):
             p.drawText(14, 30, "🔍")
         p.end()
 
+    def _input_block_height(self) -> int:
+        h = self.search_input.minimumHeight()
+        if self.prefix_hint_label.isVisible() and self.prefix_hint_label.text().strip():
+            h += self.prefix_hint_label.sizeHint().height()
+        h += 1
+        return h
+
     def _update_prefix_hint(self, query: str) -> None:
-        self.prefix_hint_label.setText(prefix_hint(query, self._cat_filt))
+        t = prefix_hint(query, self._cat_filt)
+        self.prefix_hint_label.setText(t)
+        self.prefix_hint_label.setVisible(bool(t.strip()))
+        self._layout_height_timer.start(0)
+
+    def _effective_query(self, query: str, filt: Optional[str], body: str) -> str:
+        if filt:
+            return adapt_query_for_prefix(filt, normalize_for_runners(body))
+        return normalize_for_runners(query)
 
     def _fill_repeat_results(self) -> None:
         last = load_last_repeat()
@@ -380,7 +395,7 @@ class JustWindow(QWidget):
         body, filt = parse_category_prefix(query)
         self._cat_filt = filt
         self._update_prefix_hint(query)
-        eff = adapt_query_for_prefix(filt, body) if filt else query
+        eff = self._effective_query(query, filt, body)
 
         if query == "!!":
             self._input_timer.stop()
@@ -441,7 +456,7 @@ class JustWindow(QWidget):
         if not query or query.startswith(("?", ">", "$")):
             return
         body, filt = parse_category_prefix(query)
-        eff = adapt_query_for_prefix(filt, body) if filt else query
+        eff = self._effective_query(query, filt, body)
         gen = self._heavy_gen
 
         def _work():
@@ -592,7 +607,7 @@ class JustWindow(QWidget):
         hint_h = self.results_widget.minimumSizeHint().height()
         content_h = max(hint_h, self._nominal_list_content_height())
         self.setFixedHeight(
-            _WINDOW_INPUT_BLOCK_H + content_h + _WINDOW_LIST_TAIL_PAD,
+            self._input_block_height() + content_h + _WINDOW_LIST_TAIL_PAD,
         )
 
     def _render(self):


### PR DESCRIPTION
Closes groundwork for epic #1.

- `core/nl.py`: strip conversational filler; magic prefixes unchanged
- Wire `normalize_for_runners` in GUI + `--query` / interactive CLI
- Prefix hints only when input non-empty, `.`, or `!`; dynamic input height
- Remove Cyrillic `--дебаг`; keep `--debug`

Refs #2 #6 #3